### PR TITLE
Update broken links

### DIFF
--- a/content/documentation/content.md
+++ b/content/documentation/content.md
@@ -5,13 +5,13 @@ resources:
     description: |
       The interblockchain communication protocol (IBC) is an end-to-end, connection-oriented, stateful protocol for reliable, ordered, and authenticated communication between modules on separate distributed ledgers...
     button: Download PDF v1.0
-    link: https://media.githubusercontent.com/media/cosmos/ics/master/papers/2020-05/build/paper.pdf
+    link: https://github.com/cosmos/ibc/raw/old/papers/2020-05/build/paper.pdf
   - title: Technical Specification
     slug: technical-specification
     description: |
       Download the Interblockchain Communication Protocol Specification.
     button: Download PDF v1.0.0-rc5
-    link: https://github.com/cosmos/ics/raw/master/spec.pdf
+    link: https://github.com/cosmos/ibc/raw/old/spec.pdf
 
 ibcImplementations:
   - badgeLabel: 1.0 Release


### PR DESCRIPTION
The links in this PR match the version numbers on the page. The PDFs should probably be updated but for now the change below is better than the broken links on https://ibcprotocol.org/documentation

Just saw https://github.com/interchainio/ibcprotocol.org/issues/10#issuecomment-808788396 after opening this PR. I guess the old links are still better than no links. That said, the changes here link to relatively recent versions (from 2020). 
Feel free to close this otherwise.

supersedes #11 (same but PDFs are hosted somewhere else instead)
closes #10